### PR TITLE
test: block until recent saved

### DIFF
--- a/search-java/src/main/java/uk/os/elements/search/android/providers/recents/RecentsManagerImpl.java
+++ b/search-java/src/main/java/uk/os/elements/search/android/providers/recents/RecentsManagerImpl.java
@@ -33,8 +33,8 @@ import uk.os.elements.search.android.providers.Provider;
 public class RecentsManagerImpl implements Provider, RecentsManager {
 
     // TODO: either use guava or rationalise what is happening
-    private Map<String, SearchResult> mIndex = new HashMap<>();
-    private List<SearchResult> mSearchResults = new ArrayList<>();
+    private Map<String, SearchResult> mIndex = Collections.synchronizedMap(new HashMap<String, SearchResult>());
+    private List<SearchResult> mSearchResults = Collections.synchronizedList(new ArrayList<SearchResult>());
 
     @Override
     public Observable<List<SearchResult>> last(int maxResults) {
@@ -94,7 +94,6 @@ public class RecentsManagerImpl implements Provider, RecentsManager {
             public void call(Subscriber<? super List<SearchResult>> subscriber) {
                 try {
                     List<SearchResult> results = new ArrayList<>();
-
                     synchronized (mSearchResults) {
                         for (String id : ids) {
                             if (mIndex.containsKey(id)) {
@@ -142,10 +141,10 @@ public class RecentsManagerImpl implements Provider, RecentsManager {
                             mSearchResults.remove(oldest);
                             mIndex.remove(oldestKey);
                         }
+                    }
 
-                        if (!subscriber.isUnsubscribed()) {
-                            subscriber.onCompleted();
-                        }
+                    if (!subscriber.isUnsubscribed()) {
+                        subscriber.onCompleted();
                     }
                 } catch (Exception e) {
                     if (!subscriber.isUnsubscribed()) {
@@ -175,9 +174,9 @@ public class RecentsManagerImpl implements Provider, RecentsManager {
                                 break;
                             }
                         }
-                        if (!subscriber.isUnsubscribed()) {
-                            subscriber.onCompleted();
-                        }
+                    }
+                    if (!subscriber.isUnsubscribed()) {
+                        subscriber.onCompleted();
                     }
                 } catch (Exception e) {
                     if (!subscriber.isUnsubscribed()) {

--- a/search-java/src/test/java/uk/os/elements/search/MergeSearchAndRecentsTest.java
+++ b/search-java/src/test/java/uk/os/elements/search/MergeSearchAndRecentsTest.java
@@ -65,7 +65,7 @@ public class MergeSearchAndRecentsTest {
         assertEquals(expected, actual);
 
         SearchResult third = searchBundle.getRemaining().get(2);
-        recentsManager.saveRecent(third);
+        recentsManager.saveRecent(third).toBlocking().subscribe();
 
         searchBundle = query(searchManager, query);
         actual = searchBundle.getRecents().size();
@@ -89,7 +89,7 @@ public class MergeSearchAndRecentsTest {
         assertEquals(expected, actual);
 
         SearchResult sr = searchBundle.getRemaining().get(0);
-        recentsManager.saveRecent(sr);
+        recentsManager.saveRecent(sr).toBlocking().subscribe();
         searchBundle = query(searchManager, query);
         actual = searchBundle.getRecents().size();
         expected = 1;
@@ -110,7 +110,7 @@ public class MergeSearchAndRecentsTest {
         assertFalse(hasErrors);
 
         SearchResult third = searchBundle.getRemaining().get(2);
-        recentsManager.saveRecent(third);
+        recentsManager.saveRecent(third).toBlocking().subscribe();
 
         searchManager = getBrokenSearchManagerImpl(recentsManager);
         searchBundle = query(searchManager, query);


### PR DESCRIPTION
saveRecent is an asynchronous operation - we block and subscribe in these tests to ensure that we only continue when we know that task has completed.

Regarding the race condition, I didn't once get a failed test on my MBP _but_ I did on CircleCI.
